### PR TITLE
Introduce mockedRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,36 @@ mockStdout.mockRestore();
 mockStderr.mockRestore();
 mockLog.mockRestore();
 ```
+
+### Advanced usage
+
+* You can use `mockedRun` (or `asyncMockedRun`) to set-up a virtual environment that will automatically create and restore provided mocks:
+
+```typescript
+import { mockedRun, MockedRunResult } from 'jest-mock-process';
+
+const mockRun: (_: () => any) => MockedRunResult = mockedRun({
+    stdout: mockProcessStdout,
+    stderr: mockProcessStderr,
+    exit: mockProcessExit,
+    log: mockConsoleLog,
+});
+const mocks: MockedRunResult = mockRun(() => {
+    process.stdout.write('stdout payload');
+    process.stderr.write('stderr payload');
+    process.exit(-1);
+    console.log('log payload');
+});
+expect(mocks.stdout).toHaveBeenCalledTimes(1);
+expect(mocks.log).toHaveBeenCalledWith('log payload');
+```
+
+* You can mock generic methods not supported by default in `jest-mock-process` with the `spyOnImplementing` function:
+
+```typescript
+import { spyOnImplementing } from 'jest-mock-process';
+
+const mockStdin = spyOnImplementing(process.stdin, 'read', () => '');
+process.stdin.read(1024);
+expect(mockStdin).toHaveBeenCalledWith(1024);
+```

--- a/lib/__tests__/index.test.ts
+++ b/lib/__tests__/index.test.ts
@@ -1,4 +1,3 @@
-import { resolve } from 'dns';
 import { asyncMockedRun, mockConsoleLog, mockedRun, MockedRunResult, mockProcessExit, mockProcessStderr,
     mockProcessStdout } from '../index';
 
@@ -261,12 +260,12 @@ describe('asyncMockedRun', () => {
 
     it('should call every mock once', async () => {
         result = await mockRun(() => {
-            return new Promise((res) => {
+            return new Promise((resolve) => {
                 process.stdout.write('stdout payload');
                 process.stderr.write('stderr payload');
                 process.exit(-1);
                 console.log('log payload');
-                res();
+                resolve();
             });
         });
         expect(result.mocks.stdout).toHaveBeenCalledTimes(1);
@@ -277,12 +276,12 @@ describe('asyncMockedRun', () => {
 
     it('should receive the correct arguments', async () => {
         result = await mockRun(() => {
-            return new Promise((res) => {
+            return new Promise((resolve) => {
                 process.stdout.write('stdout payload');
                 process.stderr.write('stderr payload');
                 process.exit(-1);
                 console.log('log payload');
-                res();
+                resolve();
             });
         });
         expect(result.mocks.stdout).toHaveBeenCalledWith('stdout payload');
@@ -293,8 +292,8 @@ describe('asyncMockedRun', () => {
 
     it('should receive the correct return value', async () => {
         result = await mockRun(() => {
-            return new Promise((res) => {
-                res('return string');
+            return new Promise((resolve) => {
+                resolve('return string');
             });
         });
         expect(result.result).toEqual('return string');
@@ -303,8 +302,8 @@ describe('asyncMockedRun', () => {
     it('should receive the correct thrown value', async () => {
         const expectedError = new Error('return string');
         result = await mockRun(() => {
-            return new Promise((_, rej) => {
-                rej(expectedError);
+            return new Promise((_, reject) => {
+                reject(expectedError);
             });
         });
         expect(result.error).toEqual(expectedError);

--- a/lib/__tests__/index.test.ts
+++ b/lib/__tests__/index.test.ts
@@ -1,7 +1,7 @@
-import { mockedRun, mockProcessExit, mockProcessStdout, mockProcessStderr, mockConsoleLog } from '../index';
+import { mockConsoleLog, mockedRun, mockProcessExit, mockProcessStderr, mockProcessStdout } from '../index';
 
 describe('Mock Process Exit', () => {
-    let mockExit: jest.SpyInstance<(_: number) => never>;
+    let mockExit: jest.SpyInstance<never, ArgsType<typeof process.exit>>;
 
     beforeEach(() => {
         mockExit = mockProcessExit();
@@ -47,7 +47,7 @@ describe('Mock Process Exit', () => {
 });
 
 describe('Mock Process Stdout', () => {
-    let mockStdout: jest.SpyInstance<(buffer: Buffer | string, encoding?: string, cb?: Function) => boolean>;
+    let mockStdout: jest.SpyInstance<boolean, ArgsType<typeof process.stdout.write>>;
 
     beforeEach(() => {
         mockStdout = mockProcessStdout();
@@ -99,7 +99,7 @@ describe('Mock Process Stdout', () => {
 });
 
 describe('Mock Process Stderr', () => {
-    let mockStderr: jest.SpyInstance<(buffer: Buffer | string, encoding?: string, cb?: Function) => boolean>;
+    let mockStderr: jest.SpyInstance<boolean, ArgsType<typeof process.stderr.write>>;
 
     beforeEach(() => {
         mockStderr = mockProcessStderr();
@@ -151,7 +151,7 @@ describe('Mock Process Stderr', () => {
 });
 
 describe('Mock Console Log', () => {
-    let mockLog: jest.SpyInstance<(message?: any, ...optionalParams: any[]) => void>;
+    let mockLog: jest.SpyInstance<void, ArgsType<typeof console.log>>;
 
     beforeEach(() => {
         mockLog = mockConsoleLog();
@@ -164,7 +164,7 @@ describe('Mock Console Log', () => {
     });
 
     it('should receive an object', () => {
-        const obj = {'array': [] as number[], 'null': null as number};
+        const obj = {array: [] as any[], null: null as any};
         console.log(obj);
         expect(mockLog).toHaveBeenCalledTimes(1);
         expect(mockLog).toHaveBeenCalledWith(obj);
@@ -193,14 +193,14 @@ describe('mockedRun', () => {
             exit: mockProcessExit,
             log: mockConsoleLog,
         })(() => {
-            process.stdout.write("stdout payload")
-            process.stderr.write("stderr payload")
+            process.stdout.write('stdout payload');
+            process.stderr.write('stderr payload');
             // process.exit(-1)
-            console.log("log payload")
-        })
+            console.log('log payload');
+        });
         expect(mocks.stdout).toHaveBeenCalledTimes(1);
         expect(mocks.stderr).toHaveBeenCalledTimes(1);
         expect(mocks.exit).toHaveBeenCalledTimes(0);
         expect(mocks.log).toHaveBeenCalledTimes(1);
     });
-})
+});

--- a/lib/__tests__/index.test.ts
+++ b/lib/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { mockProcessExit, mockProcessStdout, mockProcessStderr, mockConsoleLog } from '../index';
+import { mockedRun, mockProcessExit, mockProcessStdout, mockProcessStderr, mockConsoleLog } from '../index';
 
 describe('Mock Process Exit', () => {
     let mockExit: jest.SpyInstance<(_: number) => never>;
@@ -184,3 +184,23 @@ describe('Mock Console Log', () => {
         mockLog.mockRestore();
     });
 });
+
+describe('mockedRun', () => {
+    it('tracks stdout', () => {
+        const mocks = mockedRun({
+            stdout: mockProcessStdout,
+            stderr: mockProcessStderr,
+            exit: mockProcessExit,
+            log: mockConsoleLog,
+        })(() => {
+            process.stdout.write("stdout payload")
+            process.stderr.write("stderr payload")
+            // process.exit(-1)
+            console.log("log payload")
+        })
+        expect(mocks.stdout).toHaveBeenCalledTimes(1);
+        expect(mocks.stderr).toHaveBeenCalledTimes(1);
+        expect(mocks.exit).toHaveBeenCalledTimes(0);
+        expect(mocks.log).toHaveBeenCalledTimes(1);
+    });
+})

--- a/lib/__tests__/index.test.ts
+++ b/lib/__tests__/index.test.ts
@@ -188,7 +188,7 @@ describe('Mock Console Log', () => {
 
 describe('mockedRun', () => {
     let mockRun: (_: () => any) => MockedRunResult;
-    let result: MockedRunResult;
+    let mocks: MockedRunResult;
 
     beforeEach(() => {
         mockRun = mockedRun({
@@ -200,54 +200,50 @@ describe('mockedRun', () => {
     });
 
     it('should call every mock once', () => {
-        result = mockRun(() => {
+        mocks = mockRun(() => {
             process.stdout.write('stdout payload');
             process.stderr.write('stderr payload');
             process.exit(-1);
             console.log('log payload');
         });
-        expect(result.mocks.stdout).toHaveBeenCalledTimes(1);
-        expect(result.mocks.stderr).toHaveBeenCalledTimes(1);
-        expect(result.mocks.exit).toHaveBeenCalledTimes(1);
-        expect(result.mocks.log).toHaveBeenCalledTimes(1);
+        expect(mocks.stdout).toHaveBeenCalledTimes(1);
+        expect(mocks.stderr).toHaveBeenCalledTimes(1);
+        expect(mocks.exit).toHaveBeenCalledTimes(1);
+        expect(mocks.log).toHaveBeenCalledTimes(1);
     });
 
     it('should receive the correct arguments', () => {
-        result = mockRun(() => {
+        mocks = mockRun(() => {
             process.stdout.write('stdout payload');
             process.stderr.write('stderr payload');
             process.exit(-1);
             console.log('log payload');
         });
-        expect(result.mocks.stdout).toHaveBeenCalledWith('stdout payload');
-        expect(result.mocks.stderr).toHaveBeenCalledWith('stderr payload');
-        expect(result.mocks.exit).toHaveBeenCalledWith(-1);
-        expect(result.mocks.log).toHaveBeenCalledWith('log payload');
+        expect(mocks.stdout).toHaveBeenCalledWith('stdout payload');
+        expect(mocks.stderr).toHaveBeenCalledWith('stderr payload');
+        expect(mocks.exit).toHaveBeenCalledWith(-1);
+        expect(mocks.log).toHaveBeenCalledWith('log payload');
     });
 
     it('should receive the correct return value', () => {
-        result = mockRun(() => {
+        mocks = mockRun(() => {
             return 'return string';
         });
-        expect(result.result).toEqual('return string');
+        expect(mocks.result).toEqual('return string');
     });
 
     it('should receive the correct thrown value', () => {
         const expectedError = new Error('return string');
-        result = mockRun(() => {
+        mocks = mockRun(() => {
             throw expectedError;
         });
-        expect(result.error).toEqual(expectedError);
-    });
-
-    afterAll(() => {
-        result.mockRestore();
+        expect(mocks.error).toEqual(expectedError);
     });
 });
 
 describe('asyncMockedRun', () => {
     let mockRun: (_: () => any) => Promise<MockedRunResult>;
-    let result: MockedRunResult;
+    let mocks: MockedRunResult;
 
     beforeEach(() => {
         mockRun = asyncMockedRun({
@@ -259,7 +255,7 @@ describe('asyncMockedRun', () => {
     });
 
     it('should call every mock once', async () => {
-        result = await mockRun(() => {
+        mocks = await mockRun(() => {
             return new Promise((resolve) => {
                 process.stdout.write('stdout payload');
                 process.stderr.write('stderr payload');
@@ -268,14 +264,14 @@ describe('asyncMockedRun', () => {
                 resolve();
             });
         });
-        expect(result.mocks.stdout).toHaveBeenCalledTimes(1);
-        expect(result.mocks.stderr).toHaveBeenCalledTimes(1);
-        expect(result.mocks.exit).toHaveBeenCalledTimes(1);
-        expect(result.mocks.log).toHaveBeenCalledTimes(1);
+        expect(mocks.stdout).toHaveBeenCalledTimes(1);
+        expect(mocks.stderr).toHaveBeenCalledTimes(1);
+        expect(mocks.exit).toHaveBeenCalledTimes(1);
+        expect(mocks.log).toHaveBeenCalledTimes(1);
     });
 
     it('should receive the correct arguments', async () => {
-        result = await mockRun(() => {
+        mocks = await mockRun(() => {
             return new Promise((resolve) => {
                 process.stdout.write('stdout payload');
                 process.stderr.write('stderr payload');
@@ -284,32 +280,28 @@ describe('asyncMockedRun', () => {
                 resolve();
             });
         });
-        expect(result.mocks.stdout).toHaveBeenCalledWith('stdout payload');
-        expect(result.mocks.stderr).toHaveBeenCalledWith('stderr payload');
-        expect(result.mocks.exit).toHaveBeenCalledWith(-1);
-        expect(result.mocks.log).toHaveBeenCalledWith('log payload');
+        expect(mocks.stdout).toHaveBeenCalledWith('stdout payload');
+        expect(mocks.stderr).toHaveBeenCalledWith('stderr payload');
+        expect(mocks.exit).toHaveBeenCalledWith(-1);
+        expect(mocks.log).toHaveBeenCalledWith('log payload');
     });
 
     it('should receive the correct return value', async () => {
-        result = await mockRun(() => {
+        mocks = await mockRun(() => {
             return new Promise((resolve) => {
                 resolve('return string');
             });
         });
-        expect(result.result).toEqual('return string');
+        expect(mocks.result).toEqual('return string');
     });
 
     it('should receive the correct thrown value', async () => {
         const expectedError = new Error('return string');
-        result = await mockRun(() => {
+        mocks = await mockRun(() => {
             return new Promise((_, reject) => {
                 reject(expectedError);
             });
         });
-        expect(result.error).toEqual(expectedError);
-    });
-
-    afterAll(() => {
-        result.mockRestore();
+        expect(mocks.error).toEqual(expectedError);
     });
 });

--- a/lib/__tests__/index.test.ts
+++ b/lib/__tests__/index.test.ts
@@ -195,12 +195,12 @@ describe('mockedRun', () => {
         })(() => {
             process.stdout.write('stdout payload');
             process.stderr.write('stderr payload');
-            // process.exit(-1)
+            process.exit(-1);
             console.log('log payload');
         });
         expect(mocks.stdout).toHaveBeenCalledTimes(1);
         expect(mocks.stderr).toHaveBeenCalledTimes(1);
-        expect(mocks.exit).toHaveBeenCalledTimes(0);
+        expect(mocks.exit).toHaveBeenCalledTimes(1);
         expect(mocks.log).toHaveBeenCalledTimes(1);
     });
 });

--- a/lib/__tests__/index.test.ts
+++ b/lib/__tests__/index.test.ts
@@ -190,7 +190,7 @@ describe('mockedRun', () => {
     let mockRun: (_: () => any) => MockedRunResult;
     let mocks: MockedRunResult;
 
-    beforeEach(() => {
+    beforeAll(() => {
         mockRun = mockedRun({
             stdout: mockProcessStdout,
             stderr: mockProcessStderr,
@@ -245,7 +245,7 @@ describe('asyncMockedRun', () => {
     let mockRun: (_: () => any) => Promise<MockedRunResult>;
     let mocks: MockedRunResult;
 
-    beforeEach(() => {
+    beforeAll(() => {
         mockRun = asyncMockedRun({
             stdout: mockProcessStdout,
             stderr: mockProcessStderr,

--- a/lib/__tests__/index.test.ts
+++ b/lib/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { asyncMockedRun, mockConsoleLog, mockedRun, MockedRunResult, mockProcess
     mockProcessStdout } from '../index';
 
 describe('Mock Process Exit', () => {
-    let mockExit: jest.SpyInstance<ReturnType<typeof process.exit>, ArgsType<typeof process.exit>>;
+    let mockExit: jest.SpyInstance;
 
     beforeEach(() => {
         mockExit = mockProcessExit();
@@ -48,7 +48,7 @@ describe('Mock Process Exit', () => {
 });
 
 describe('Mock Process Stdout', () => {
-    let mockStdout: jest.SpyInstance<ReturnType<typeof process.stdout.write>, ArgsType<typeof process.stdout.write>>;
+    let mockStdout: jest.SpyInstance;
 
     beforeEach(() => {
         mockStdout = mockProcessStdout();
@@ -100,7 +100,7 @@ describe('Mock Process Stdout', () => {
 });
 
 describe('Mock Process Stderr', () => {
-    let mockStderr: jest.SpyInstance<ReturnType<typeof process.stderr.write>, ArgsType<typeof process.stderr.write>>;
+    let mockStderr: jest.SpyInstance;
 
     beforeEach(() => {
         mockStderr = mockProcessStderr();
@@ -152,7 +152,7 @@ describe('Mock Process Stderr', () => {
 });
 
 describe('Mock Console Log', () => {
-    let mockLog: jest.SpyInstance<ReturnType<typeof console.log>, ArgsType<typeof console.log>>;
+    let mockLog: jest.SpyInstance;
 
     beforeEach(() => {
         mockLog = mockConsoleLog();
@@ -226,22 +226,24 @@ describe('mockedRun', () => {
             return 'return string';
         });
         expect(mocks.result).toEqual('return string');
+        expect(mocks.error).toBeUndefined();
     });
 
     it('should receive the correct thrown value', () => {
-        const expectedError = new Error('return string');
+        const expectedError = new Error('Mock error');
         mocks = mockRun(() => {
             throw expectedError;
         });
-        expect(mocks.error).toEqual(expectedError);
+        expect(mocks.result).toBeUndefined();
+        expect(mocks.error).toBe(expectedError);
     });
 
     it('should accept mocked process.exit raising an error', () => {
-        const error = new Error('Mock process exit');
+        const expectedError = new Error('Mock process exit');
         const mockRunWithProcessExit = mockedRun({
             stdout: mockProcessStdout,
             stderr: mockProcessStderr,
-            exit: () => mockProcessExit(error),
+            exit: () => mockProcessExit(expectedError),
             log: mockConsoleLog,
         });
         mocks = mockRunWithProcessExit(() => {
@@ -254,7 +256,8 @@ describe('mockedRun', () => {
         expect(mocks.stderr).toHaveBeenCalledTimes(1);
         expect(mocks.exit).toHaveBeenCalledTimes(1);
         expect(mocks.log).not.toHaveBeenCalled();
-        expect(mocks.error).toBe(error);
+        expect(mocks.result).toBeUndefined();
+        expect(mocks.error).toBe(expectedError);
     });
 });
 
@@ -306,24 +309,26 @@ describe('asyncMockedRun', () => {
             });
         });
         expect(mocks.result).toEqual('return string');
+        expect(mocks.error).toBeUndefined();
     });
 
     it('should receive the correct thrown value', async () => {
-        const expectedError = new Error('return string');
+        const expectedError = new Error('Mock error');
         mocks = await mockRun(() => {
             return new Promise((_, reject) => {
                 reject(expectedError);
             });
         });
-        expect(mocks.error).toEqual(expectedError);
+        expect(mocks.result).toBeUndefined();
+        expect(mocks.error).toBe(expectedError);
     });
 
     it('should accept mocked process.exit raising an error', async () => {
-        const error = new Error('Mock process exit');
+        const expectedError = new Error('Mock process exit');
         const mockRunWithProcessExit = asyncMockedRun({
             stdout: mockProcessStdout,
             stderr: mockProcessStderr,
-            exit: () => mockProcessExit(error),
+            exit: () => mockProcessExit(expectedError),
             log: mockConsoleLog,
         });
         mocks = await mockRunWithProcessExit(() => {
@@ -339,6 +344,7 @@ describe('asyncMockedRun', () => {
         expect(mocks.stderr).toHaveBeenCalledTimes(1);
         expect(mocks.exit).toHaveBeenCalledTimes(1);
         expect(mocks.log).not.toHaveBeenCalled();
-        expect(mocks.error).toBe(error);
+        expect(mocks.result).toBeUndefined();
+        expect(mocks.error).toBe(expectedError);
     });
 });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -50,3 +50,16 @@ export const mockConsoleLog = () => spyOnImplementing(
     'log',
     () => {},
 )
+
+/**
+ * Helper function to run a function with certain mocks in place.
+ */
+export const mockedRun = (callers: { [K in keyof any]: () => jest.SpyInstance}) => (f: () => void) => {
+    let mocks = Object.entries(callers)
+        .map(([k, mocker]) => [k, mocker()])
+        .reduce((o: any, [k, v]: any) => {o[k] = v; return o}, {})
+
+    f()
+
+    return mocks as Record<keyof typeof callers, jest.SpyInstance>
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
-const maybeMockRestore = (a: any): void => a.mockRestore ? a.mockRestore() : undefined;
+const maybeMockRestore = (a: any): void =>
+    a.mockRestore && typeof a.mockRestore === 'function' ? a.mockRestore() : undefined;
 
 type FunctionPropertyNames<T> = {[K in keyof T]: T[K] extends (...args: any[]) => any ? K : never}[keyof T];
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,10 +1,13 @@
 const maybeMockRestore = (a: any): void => a.mockRestore ? a.mockRestore() : undefined;
 
-function spyOnImplementing<
+type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never }[keyof T];
+
+export function spyOnImplementing<
     T extends object,
-    M extends keyof T,
-    F extends T[M] extends (...args: any[]) => any ? T[M] : never,
->(target: T, property: M, impl: F): jest.SpyInstance<ReturnType<F>, ArgsType<F>> {
+    M extends FunctionPropertyNames<T>,
+    F extends T[M],
+    I extends (...args: any[]) => any,
+>(target: T, property: M, impl: I): jest.SpyInstance<ReturnType<F>, ArgsType<F>> {
     maybeMockRestore(target[property]);
     return jest.spyOn(target, property).mockImplementation(impl);
 }
@@ -19,7 +22,7 @@ function spyOnImplementing<
 export const mockProcessExit = (err?: any) => spyOnImplementing(
     process,
     'exit',
-    (err ? (_?: number) => { throw err; } : ((_?: number) => {})) as typeof process.exit
+    (err ? (_?: number) => { throw err; } : ((_?: number) => {}))
 );
 
 /**
@@ -29,7 +32,7 @@ export const mockProcessExit = (err?: any) => spyOnImplementing(
 export const mockProcessStdout = () => spyOnImplementing(
     process.stdout,
     'write',
-    (() => true) as typeof process.stdout.write,
+    (() => true),
 );
 
 /**
@@ -39,7 +42,7 @@ export const mockProcessStdout = () => spyOnImplementing(
 export const mockProcessStderr = () => spyOnImplementing(
     process.stderr,
     'write',
-    (() => true) as typeof process.stderr.write,
+    (() => true),
 );
 
 /**
@@ -49,7 +52,7 @@ export const mockProcessStderr = () => spyOnImplementing(
 export const mockConsoleLog = () => spyOnImplementing(
     console,
     'log',
-    (() => {}) as typeof console.log,
+    (() => {}),
 );
 
 export interface MockedRunMocks {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -70,14 +70,16 @@ export interface MockedRunResult {
 }
 
 /**
- * Helper function to run a synchronous function with provided mocks in place.
+ * Helper function to run a synchronous function with provided mocks in place, as a virtual environment.
+ *
+ * Every provided mock will be automatically restored when this function returns.
  */
 export const mockedRun = (
     callers: {[_: string]: () => jest.SpyInstance}
 ) => (f: () => any) => {
     const mocks: MockedRunResult = {};
-    const mockers: {[_: string]: jest.SpyInstance} = Object.entries(callers).map(([k, caller]) => ({[k]: caller()}))
-        .reduce((o, acc) => ({...acc, ...o}));
+    const mockers: {[_: string]: jest.SpyInstance} = Object.entries(callers)
+        .map(([k, caller]) => ({[k]: caller()})).reduce((o, acc) => Object.assign(acc, o), {});
 
     try {
         mocks.result = f();
@@ -94,14 +96,16 @@ export const mockedRun = (
 };
 
 /**
- * Helper function to run an asynchronous function with provided mocks in place.
+ * Helper function to run an asynchronous function with provided mocks in place, as a virtual environment.
+ *
+ * Every provided mock will be automatically restored when this function returns.
  */
 export const asyncMockedRun = (
     callers: {[_: string]: () => jest.SpyInstance}
 ) => async (f: () => Promise<any>) => {
     const mocks: MockedRunResult = {};
-    const mockers: {[_: string]: jest.SpyInstance} = Object.entries(callers).map(([k, caller]) => ({[k]: caller()}))
-        .reduce((o, acc) => ({...acc, ...o}));
+    const mockers: {[_: string]: jest.SpyInstance} = Object.entries(callers)
+        .map(([k, caller]) => ({[k]: caller()})).reduce((o, acc) => Object.assign(acc, o), {});
 
     try {
         mocks.result = await f();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,13 @@
+const maybeMockRestore = (a: any): void => a.mockRestore ? a.mockRestore() : undefined
+
+export function spyOnImplementing<
+    T extends object,
+    M extends keyof T,
+    F extends T[M] extends (...args: any[]) => any ? T[M] : never,
+>(target: T, property: M, impl: F): jest.SpyInstance  {
+    maybeMockRestore(target[property])
+    return jest.spyOn(target, property).mockImplementation(impl)
+}
 /**
  * Helper function to create a mock of the Node.js method
  * `process.exit(code: number)`.
@@ -5,76 +15,38 @@
  * @param {Object} err Optional error to raise. If unspecified or falsy, calling `process.exit` will resume code
  * execution instead of raising an error.
  */
-export function mockProcessExit(err?: any) {
-    const processExit = process.exit as any;
-    if (processExit.mockRestore) {
-        processExit.mockRestore();
-    }
-    let spyImplementation: any;
-    if (err) {
-        spyImplementation = jest.spyOn(process, 'exit')
-            .mockImplementation((_?: number) => {throw err});
-    } else {
-        spyImplementation = (jest.spyOn(process, 'exit') as any)
-            .mockImplementation((_?: number) => {});
-    }
-    return spyImplementation as jest.SpyInstance<(
-        code?: number
-    ) => never>;
-};
+export const mockProcessExit = (err?: any) => spyOnImplementing(
+    process,
+    'exit',
+    err ? (_?: number) => {throw err} : ((_?: number) => {}) as (_?: number) => never
+)
 
 /**
  * Helper function to create a mock of the Node.js method
  * `process.stdout.write(text: string, callback?: function): boolean`.
  */
-export function mockProcessStdout() {
-    const processStdout = process.stdout.write as any;
-    if (processStdout.mockRestore) {
-        processStdout.mockRestore();
-    }
-    let spyImplementation: any;
-    spyImplementation = jest.spyOn(process.stdout, 'write')
-        .mockImplementation(() => true);
-    return spyImplementation as jest.SpyInstance<(
-        buffer: Buffer | string,
-        encoding?: string,
-        cb?: Function
-    ) => boolean>;
-};
+export const mockProcessStdout = () => spyOnImplementing(
+    process.stdout,
+    'write',
+    () => true,
+)
 
 /**
  * Helper function to create a mock of the Node.js method
  * `process.stderr.write(text: string, callback?: function): boolean`.
  */
-export function mockProcessStderr() {
-    const processStderr = process.stderr.write as any;
-    if (processStderr.mockRestore) {
-        processStderr.mockRestore();
-    }
-    let spyImplementation: any;
-    spyImplementation = jest.spyOn(process.stderr, 'write')
-        .mockImplementation(() => true);
-    return spyImplementation as jest.SpyInstance<(
-        buffer: Buffer | string,
-        encoding?: string,
-        cb?: Function
-    ) => boolean>;
-};
+export const mockProcessStderr = () => spyOnImplementing(
+    process.stderr,
+    'write',
+    () => true,
+)
 
 /**
  * Helper function to create a mock of the Node.js method
  * `console.log(message: any)`.
  */
-export function mockConsoleLog() {
-    const consoleLog = console.log as any;
-    if (consoleLog.mockRestore) {
-        consoleLog.mockRestore();
-    }
-    let spyImplementation: any;
-    spyImplementation = jest.spyOn(console, 'log')
-        .mockImplementation(() => {});
-    return spyImplementation as jest.SpyInstance<(
-        message?: any,
-        ...optionalParams: any[]
-    ) => void>;
-};
+export const mockConsoleLog = () => spyOnImplementing(
+    console,
+    'log',
+    () => {},
+)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,12 +1,19 @@
 const maybeMockRestore = (a: any): void => a.mockRestore ? a.mockRestore() : undefined;
 
-type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never }[keyof T];
+type FunctionPropertyNames<T> = {[K in keyof T]: T[K] extends (...args: any[]) => any ? K : never}[keyof T];
 
+/**
+ * Helper function for manually creating new spy mocks of functions not supported by this module.
+ *
+ * @param target Object containing the function that will be mocked.
+ * @param property Name of the function that will be mocked.
+ * @param impl Mock implementation of the. The return type must match the target function.
+ */
 export function spyOnImplementing<
     T extends object,
     M extends FunctionPropertyNames<T>,
     F extends T[M],
-    I extends (...args: any[]) => any,
+    I extends (...args: any[]) => ReturnType<F>,
 >(target: T, property: M, impl: I): jest.SpyInstance<ReturnType<F>, ArgsType<F>> {
     maybeMockRestore(target[property]);
     return jest.spyOn(target, property).mockImplementation(impl);
@@ -22,7 +29,7 @@ export function spyOnImplementing<
 export const mockProcessExit = (err?: any) => spyOnImplementing(
     process,
     'exit',
-    (err ? (_?: number) => { throw err; } : ((_?: number) => {}))
+    (err ? (_?: number) => { throw err; } : ((_?: number) => {})) as () => never,
 );
 
 /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,13 +1,14 @@
-const maybeMockRestore = (a: any): void => a.mockRestore ? a.mockRestore() : undefined
+const maybeMockRestore = (a: any): void => a.mockRestore ? a.mockRestore() : undefined;
 
 export function spyOnImplementing<
     T extends object,
     M extends keyof T,
     F extends T[M] extends (...args: any[]) => any ? T[M] : never,
->(target: T, property: M, impl: F): jest.SpyInstance  {
-    maybeMockRestore(target[property])
-    return jest.spyOn(target, property).mockImplementation(impl)
+>(target: T, property: M, impl: F): jest.SpyInstance<ReturnType<F>, ArgsType<F>> {
+    maybeMockRestore(target[property]);
+    return jest.spyOn(target, property).mockImplementation(impl);
 }
+
 /**
  * Helper function to create a mock of the Node.js method
  * `process.exit(code: number)`.
@@ -18,8 +19,8 @@ export function spyOnImplementing<
 export const mockProcessExit = (err?: any) => spyOnImplementing(
     process,
     'exit',
-    err ? (_?: number) => {throw err} : ((_?: number) => {}) as (_?: number) => never
-)
+    (err ? (_?: number) => { throw err; } : ((_?: number) => {})) as typeof process.exit
+);
 
 /**
  * Helper function to create a mock of the Node.js method
@@ -28,8 +29,8 @@ export const mockProcessExit = (err?: any) => spyOnImplementing(
 export const mockProcessStdout = () => spyOnImplementing(
     process.stdout,
     'write',
-    () => true,
-)
+    (() => true) as typeof process.stdout.write,
+);
 
 /**
  * Helper function to create a mock of the Node.js method
@@ -38,8 +39,8 @@ export const mockProcessStdout = () => spyOnImplementing(
 export const mockProcessStderr = () => spyOnImplementing(
     process.stderr,
     'write',
-    () => true,
-)
+    (() => true) as typeof process.stderr.write,
+);
 
 /**
  * Helper function to create a mock of the Node.js method
@@ -48,18 +49,18 @@ export const mockProcessStderr = () => spyOnImplementing(
 export const mockConsoleLog = () => spyOnImplementing(
     console,
     'log',
-    () => {},
-)
+    (() => {}) as typeof console.log,
+);
 
 /**
  * Helper function to run a function with certain mocks in place.
  */
 export const mockedRun = (callers: { [K in keyof any]: () => jest.SpyInstance}) => (f: () => void) => {
-    let mocks = Object.entries(callers)
+    const mocks = Object.entries(callers)
         .map(([k, mocker]) => [k, mocker()])
-        .reduce((o: any, [k, v]: any) => {o[k] = v; return o}, {})
+        .reduce((o: any, [k, v]: any) => { o[k] = v; return o; }, {});
 
-    f()
+    f();
 
-    return mocks as Record<keyof typeof callers, jest.SpyInstance>
-}
+    return mocks as Record<keyof typeof callers, jest.SpyInstance>;
+};

--- a/tslint.json
+++ b/tslint.json
@@ -16,6 +16,7 @@
 		"no-implicit-dependencies": [true, "dev"],
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
-		"interface-name": false
+		"interface-name": false,
+		"no-console": false
 	}
 }


### PR DESCRIPTION
Initial try at something that works for #3. I'm not super happy about the interface I got to (the test looks super clunky and verbose), but I can't image a much better API. Looking for feedback there.

Another annoyance is that, unlike the method described in #3, I can't restore the mocks after calling `f()`, as that resets their info. This worked in the original because we were reaching for `mockedFn.mock.calls`, which doesn't get blown away on reset. This leaves me in a position where I either don't have something to assert on, or this method is not that useful anymore.

I've also refactored the central mechanism into something more DRY. This was handy to catch `impl` signatures not matching (like on https://github.com/EpicEric/jest-mock-process/blob/82460c748fe1d151b30518517fe50b8aec7eb30f/lib/index.ts#L19). Even though that came with some trouble (I now have a `// @ts-ignore TS2345`), I think this is a good step forward.

TODO
- [x] Figure out a nicer API for `mockedRun`
- [x] Get rid of `// @ts-ignore TS2345`
- [x] Figure out how to restore and keep the mock info available
- [x] Figure out why `mockProcessExit` is not working on `mockedRun`'s tests
